### PR TITLE
Update InlineChartWidget.php

### DIFF
--- a/src/InlineChartWidget.php
+++ b/src/InlineChartWidget.php
@@ -18,7 +18,7 @@ abstract class InlineChartWidget extends ChartWidget
 
     protected ?string $maxHeight = '50';
 
-    public Model $record;
+    public ?Model $record = null;
 
     protected function getOptions(): RawJs
     {


### PR DESCRIPTION
Fix potential error on Dashboard "Cannot assign null to property LaraZeus\InlineChart\InlineChartWidget::$record of type Illuminate\Database\Eloquent\Model "