### PR TITLE
Instead of overriding height and width, set max-width/max-height.

### DIFF
--- a/resources/views/widgets/inline-chart.blade.php
+++ b/resources/views/widgets/inline-chart.blade.php
@@ -33,8 +33,8 @@
                 <canvas
                     x-ref="canvas"
                     style="
-                        width: {{ (int) $maxWidth }}px !important;
-                        height: {{ (int) $this->getMaxHeight() }}px !important;
+                        max-width: {{ (int) $maxWidth }}px;
+                        max-height: {{ (int) $this->getMaxHeight() }}px;
                     "
                 ></canvas>
 


### PR DESCRIPTION
Without this, on Filament 4.x, when rendering the chart widget each instance grows vertically forever.

Without this:
![InlineChart busted on Filament 4](https://github.com/user-attachments/assets/a033da7b-73b9-4ecf-a6d7-45cb3e5f4177)

With this, it renders as expected. I'm not positive if it's the correct fix but it works for our use case at least!